### PR TITLE
Introduire IsolatesDataPathEnvTrait pour capturer/restaurer $_ENV et …

### DIFF
--- a/src/DataFolder.php
+++ b/src/DataFolder.php
@@ -11,7 +11,7 @@ class DataFolder implements DataFolderPathInterface
 
     public function getDataRootFolder(): string
     {
-        return $_ENV["DATA_PATH"];
+        return $_ENV[self::DATA_PATH_NAME];
     }
 
     public function getTenantDataFolder(?string $tenantId = null): string

--- a/tests/unit/Command/CreateTenantDatabaseCommandTest.php
+++ b/tests/unit/Command/CreateTenantDatabaseCommandTest.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Phariscope\MultiTenant\Command\CreateTenantDatabaseCommand;
 use Phariscope\MultiTenant\Doctrine\Tools\ParamsConnection;
 use Phariscope\MultiTenant\Tests\Doctrine\Tools\FakeEntityManagerFactory;
+use Phariscope\MultiTenant\Tests\Share\IsolatesDataPathEnvTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Application;
@@ -15,21 +16,23 @@ use function SafePHP\strval;
 
 class CreateTenantDatabaseCommandTest extends TestCase
 {
+    use IsolatesDataPathEnvTrait;
+
     private CommandTester $commandTester;
 
     private EntityManager $em;
 
     protected function setUp(): void
     {
-
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
         $this->em = (new FakeEntityManagerFactory())->createSqliteEntityManager();
-
         $this->commandTester = $this->createCommandTester();
+        $this->setUpIsolatedWritableDataPath();
     }
 
     protected function tearDown(): void
     {
+        $this->tearDownIsolatedDataPath();
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
     }
 
@@ -88,5 +91,21 @@ class CreateTenantDatabaseCommandTest extends TestCase
 
         // clean up
         $filesystem->remove($tenantDbPath);
+    }
+
+    public function testExecuteFailureWhenTenantIdMissing(): void
+    {
+        // Arrange
+        $saved = $this->captureDataPathEnv();
+        $this->clearDataPathEnv();
+
+        // Act
+        $exitCode = $this->commandTester->execute([]);
+
+        // Assert
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Provide --tenant_id', $this->commandTester->getDisplay());
+
+        $this->restoreDataPathEnv($saved);
     }
 }

--- a/tests/unit/Command/CreateTenantSchemaCommandTest.php
+++ b/tests/unit/Command/CreateTenantSchemaCommandTest.php
@@ -5,40 +5,32 @@ namespace Phariscope\MultiTenant\Tests\Commmand;
 use Doctrine\ORM\EntityManager;
 use Phariscope\MultiTenant\Command\CreateTenantDatabaseCommand;
 use Phariscope\MultiTenant\Command\CreateTenantSchemaCommand;
-use Phariscope\MultiTenant\Doctrine\DatabaseTools;
-use Phariscope\MultiTenant\Doctrine\EntityManagerResolver;
 use Phariscope\MultiTenant\Tests\Doctrine\Tools\FakeEntityManagerFactory;
+use Phariscope\MultiTenant\Tests\Share\IsolatesDataPathEnvTrait;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class CreateTenantSchemaCommandTest extends TestCase
 {
+    use IsolatesDataPathEnvTrait;
+
     private CommandTester $commandTester;
 
     private EntityManager $em;
-
-    private string $initialDataPath;
 
     protected function setUp(): void
     {
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
         $this->em = (new FakeEntityManagerFactory())->createSqliteEntityManager();
         $this->commandTester = $this->createCommandTester();
-
-        if (isset($_ENV['DATA_PATH'])) {
-            $this->initialDataPath = $_ENV['DATA_PATH'];
-            unset($_ENV['DATA_PATH']);
-        }
+        $this->setUpIsolatedWritableDataPath();
     }
 
     protected function tearDown(): void
     {
-        if (isset($this->initialDataPath)) {
-            $_ENV['DATA_PATH'] = $this->initialDataPath;
-        } else {
-            unset($_ENV['DATA_PATH']);
-        }
+        $this->tearDownIsolatedDataPath();
+        (new FakeEntityManagerFactory())->cleanSqliteDatabase();
     }
 
     private function createCommandTester(): CommandTester
@@ -121,5 +113,21 @@ class CreateTenantSchemaCommandTest extends TestCase
             'Could not create schema for tenant "' . $expectedTenantId,
             $output
         );
+    }
+
+    public function testExecuteFailureWhenTenantIdMissing(): void
+    {
+        // Arrange
+        $saved = $this->captureDataPathEnv();
+        $this->clearDataPathEnv();
+
+        // Act
+        $exitCode = $this->commandTester->execute([]);
+
+        // Assert
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Provide --tenant_id', $this->commandTester->getDisplay());
+
+        $this->restoreDataPathEnv($saved);
     }
 }

--- a/tests/unit/Command/UpdateTenantSchemaCommandTest.php
+++ b/tests/unit/Command/UpdateTenantSchemaCommandTest.php
@@ -4,26 +4,35 @@ declare(strict_types=1);
 
 namespace Phariscope\MultiTenant\Tests\Command;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
+use Mockery;
 use Phariscope\MultiTenant\Command\CreateTenantDatabaseCommand;
 use Phariscope\MultiTenant\Command\UpdateTenantSchemaCommand;
 use Phariscope\MultiTenant\Tests\Doctrine\Tools\FakeEntityManagerFactory;
+use Phariscope\MultiTenant\Tests\Share\IsolatesDataPathEnvTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class UpdateTenantSchemaCommandTest extends TestCase
 {
+    use IsolatesDataPathEnvTrait;
+
     private EntityManager $em;
 
     protected function setUp(): void
     {
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
         $this->em = (new FakeEntityManagerFactory())->createSqliteEntityManager();
+        $this->setUpIsolatedWritableDataPath();
     }
 
     protected function tearDown(): void
     {
+        Mockery::close();
+        $this->tearDownIsolatedDataPath();
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
     }
 
@@ -150,6 +159,48 @@ class UpdateTenantSchemaCommandTest extends TestCase
         $this->assertStringContainsString('CREATE TABLE', $output);
         $this->assertStringContainsString(
             'Schema for tenant "' . $tenantId . '" updated successfully.',
+            $output
+        );
+    }
+
+    public function testExecuteFailureWhenTenantIdMissing(): void
+    {
+        // Arrange
+        $saved = $this->captureDataPathEnv();
+        $this->clearDataPathEnv();
+        $commandTester = $this->createUpdateCommandTester();
+
+        // Act
+        $exitCode = $commandTester->execute([]);
+
+        // Assert
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Provide --tenant_id', $commandTester->getDisplay());
+
+        $this->restoreDataPathEnv($saved);
+    }
+
+    public function testReportsSchemaUpToDateWhenNoPendingChanges(): void
+    {
+        // Arrange
+        $tenantId = 'tenant123';
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $config = ORMSetup::createXMLMetadataConfiguration([], true);
+        $em = new EntityManager($connection, $config);
+        $application = new Application();
+        $application->add(new UpdateTenantSchemaCommand($em));
+        $commandTester = new CommandTester($application->find('tenant:schema:update'));
+
+        // Act
+        $exitCode = $commandTester->execute([
+            '--tenant_id' => $tenantId,
+        ]);
+
+        // Assert
+        $output = $commandTester->getDisplay();
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertStringContainsString(
+            'Schema for tenant "' . $tenantId . '" is up to date.',
             $output
         );
     }

--- a/tests/unit/DataFolderTest.php
+++ b/tests/unit/DataFolderTest.php
@@ -3,10 +3,23 @@
 namespace Phariscope\MultiTenant\Tests;
 
 use Phariscope\MultiTenant\DataFolder;
+use Phariscope\MultiTenant\Tests\Share\IsolatesDataPathEnvTrait;
 use PHPUnit\Framework\TestCase;
 
 class DataFolderTest extends TestCase
 {
+    use IsolatesDataPathEnvTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpDataPathEnvSnapshot();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownDataPathEnvSnapshot();
+    }
+
     public function testGetDataRootFolder(): void
     {
         // Arrange

--- a/tests/unit/Doctrine/DatabaseToolsTest.php
+++ b/tests/unit/Doctrine/DatabaseToolsTest.php
@@ -2,6 +2,13 @@
 
 namespace Phariscope\MultiTenant\Tests\Doctrine;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception as PdoDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Mockery;
 use Phariscope\MultiTenant\Doctrine\DatabaseTools;
 use Phariscope\MultiTenant\Doctrine\Tools\ParamsConnection;
 use Phariscope\MultiTenant\Tests\Doctrine\Tools\FakeEntityManagerFactory;
@@ -15,6 +22,12 @@ class DatabaseToolsTest extends TestCase
     {
         parent::setUp();
         (new FakeEntityManagerFactory())->cleanSqliteDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 
     public function testCreateSqliteDatabase(): void
@@ -125,5 +138,107 @@ class DatabaseToolsTest extends TestCase
         $joined = implode(' ', $sqls);
         $this->assertStringContainsString('entities', $joined);
         $this->assertStringContainsStringIgnoringCase('CREATE', $joined);
+    }
+
+    public function testCreateSqliteDatabaseThrowsWhenFileAlreadyExists(): void
+    {
+        // Arrange
+        $em = (new FakeEntityManagerFactory())->createSqliteEntityManager();
+        $sut = new DatabaseTools();
+        $sut->createDatabase($em);
+
+        // Act & Assert
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('already exists');
+        $sut->createDatabase($em);
+    }
+
+    public function testDatabaseExistsReturnsFalseWhenConnectionFails(): void
+    {
+        // Arrange
+        $driverException = PdoDriverException::new(new \PDOException('Connection refused'));
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('listDatabases')
+            ->willThrowException(new ConnectionException($driverException, null));
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $connection->method('getParams')->willReturn(['dbname' => 'test']);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($connection);
+        $sut = new DatabaseTools();
+
+        // Act
+        $exists = $sut->databaseExists($em);
+
+        // Assert
+        $this->assertFalse($exists);
+    }
+
+    public function testDatabaseExistsReturnsTrueForNonSqliteWhenConnectionWorks(): void
+    {
+        // Arrange
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('listDatabases')->willReturn(['mydbname']);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $connection->method('getParams')->willReturn(['dbname' => 'mydbname']);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($connection);
+        $sut = new DatabaseTools();
+
+        // Act
+        $exists = $sut->databaseExists($em);
+
+        // Assert
+        $this->assertTrue($exists);
+    }
+
+    public function testCreateMysqlDatabase(): void
+    {
+        // Arrange
+        $this->skipIfMariaDbUnavailable();
+        (new FakeEntityManagerFactory())->cleanMariadbDatabase();
+        $em = (new FakeEntityManagerFactory())->createMariadbEntityManager();
+        $sut = new DatabaseTools();
+
+        // Act
+        $sut->createDatabase($em);
+        $params = $em->getConnection()->getParams();
+
+        // Assert
+        $this->assertSame(FakeEntityManagerFactory::MARIADB_DATABASE_NAME, $params['dbname'] ?? null);
+        $this->assertTrue($sut->databaseExists($em));
+    }
+
+    public function testMysqlDatabaseDrop(): void
+    {
+        // Arrange
+        $this->skipIfMariaDbUnavailable();
+        (new FakeEntityManagerFactory())->cleanMariadbDatabase();
+        $em = (new FakeEntityManagerFactory())->createMariadbEntityManager();
+        $sut = new DatabaseTools();
+        $sut->createDatabase($em);
+
+        // Act
+        $sut->dropDatabase($em);
+
+        // Assert
+        $this->assertFalse($sut->databaseExists($em));
+    }
+
+    private function skipIfMariaDbUnavailable(): void
+    {
+        try {
+            (new FakeEntityManagerFactory())->cleanMariadbDatabase();
+        } catch (\Throwable) {
+            $this->markTestSkipped('MariaDB is not available for non-SQLite DatabaseTools coverage.');
+        }
     }
 }

--- a/tests/unit/Doctrine/Tools/FakeEntityManagerFactory.php
+++ b/tests/unit/Doctrine/Tools/FakeEntityManagerFactory.php
@@ -17,10 +17,20 @@ class FakeEntityManagerFactory
 
     public const MARIADB_DATABASE_NAME = 'mydbname';
 
+    public static function projectRoot(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+
+    public static function sqliteDatabaseAbsolutePath(): string
+    {
+        return self::projectRoot() . self::SQLITE_DATABASE_PATH;
+    }
+
     public function cleanSqliteDatabase(): void
     {
         $fs = new Filesystem();
-        $fs->remove(getcwd() . self::DATA_PATH);
+        $fs->remove(self::projectRoot() . self::DATA_PATH);
     }
 
     public function createSqliteEntityManager(): EntityManager
@@ -28,7 +38,7 @@ class FakeEntityManagerFactory
         $connection = DriverManager::getConnection(
             [
                 'driver' => 'pdo_sqlite',
-                'path' => getcwd() . self::SQLITE_DATABASE_PATH,
+                'path' => self::sqliteDatabaseAbsolutePath(),
             ]
         );
         return $this->createEntityManager($connection);

--- a/tests/unit/Doctrine/Tools/TenantManagerTest.php
+++ b/tests/unit/Doctrine/Tools/TenantManagerTest.php
@@ -387,4 +387,230 @@ class TenantManagerTest extends TestCase
             }
         }
     }
+
+    public function testResolvesTenantShortnameFromRequestSuperglobal(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-req-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-req', 'slug-req');
+            $_REQUEST['tenant_shortname'] = 'slug-req';
+            $sut = new TenantManager();
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-req', $tenantId);
+        } finally {
+            unset($_REQUEST['tenant_shortname']);
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testResolvesTenantShortnameFromGet(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-get-sn-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-get-sn', 'slug-get');
+            $_GET['tenant_shortname'] = 'slug-get';
+            $sut = new TenantManager();
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-get-sn', $tenantId);
+        } finally {
+            unset($_GET['tenant_shortname']);
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testResolvesTenantShortnameFromPost(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-post-sn-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-post-sn', 'slug-post');
+            $_POST['tenant_shortname'] = 'slug-post';
+            $sut = new TenantManager();
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-post-sn', $tenantId);
+        } finally {
+            unset($_POST['tenant_shortname']);
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testResolvesTenantShortnameFromSession(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-sess-sn-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-sess-sn', 'slug-sess');
+            $session = ['tenant_shortname' => 'slug-sess'];
+            $sut = new TenantManager(null, $session);
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-sess-sn', $tenantId);
+        } finally {
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testResolvesTenantShortnameFromCookie(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-cookie-sn-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-cookie-sn', 'slug-cookie');
+            $_COOKIE['tenant_shortname'] = 'slug-cookie';
+            $sut = new TenantManager();
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-cookie-sn', $tenantId);
+        } finally {
+            unset($_COOKIE['tenant_shortname']);
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testReturnsNullWhenShortnameCannotBeResolvedWithoutRegistry(): void
+    {
+        // Arrange
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+        unset($_ENV['DATA_PATH']);
+        putenv('DATA_PATH');
+        $_SERVER['HTTP_X_TENANT_SHORTNAME'] = 'unknown-slug';
+        $sut = new TenantManager();
+
+        // Act
+        $tenantId = $sut->getCurrentTenantId();
+
+        // Assert
+        $this->assertNull($tenantId);
+
+        unset($_SERVER['HTTP_X_TENANT_SHORTNAME']);
+        $this->restoreDataPath($hadKey, $previous);
+    }
+
+    public function testResolvesShortnameFromSymfonyPost(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-sf-post-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-sf-post', 'slug-sf-post');
+            $request = new Request([], ['tenant_shortname' => 'slug-sf-post']);
+            $sut = new TenantManager($request);
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-sf-post', $tenantId);
+        } finally {
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testResolvesShortnameFromSymfonyCookie(): void
+    {
+        // Arrange
+        $tmp = sys_get_temp_dir() . '/mt-tm-sf-cookie-' . uniqid('', true);
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+
+        try {
+            $_ENV['DATA_PATH'] = $tmp;
+            putenv('DATA_PATH=' . $tmp);
+            TenantShortnameRegistry::fromApplicationDataPath($tmp)->register('tid-sf-cookie', 'slug-sf-cookie');
+            $request = new Request([], [], [], ['tenant_shortname' => 'slug-sf-cookie']);
+            $sut = new TenantManager($request);
+
+            // Act
+            $tenantId = $sut->getCurrentTenantId();
+
+            // Assert
+            $this->assertSame('tid-sf-cookie', $tenantId);
+        } finally {
+            (new Filesystem())->remove($tmp);
+            $this->restoreDataPath($hadKey, $previous);
+        }
+    }
+
+    public function testEmptySymfonyShortnameHeaderReturnsNull(): void
+    {
+        // Arrange
+        $request = new Request([], [], [], [], [], ['HTTP_X_TENANT_SHORTNAME' => '']);
+        $sut = new TenantManager($request);
+
+        // Act
+        $tenantId = $sut->getCurrentTenantId();
+
+        // Assert
+        $this->assertNull($tenantId);
+    }
+
+    /**
+     * @param mixed $previous
+     */
+    private function restoreDataPath(bool $hadKey, mixed $previous): void
+    {
+        if ($hadKey && is_string($previous)) {
+            $_ENV['DATA_PATH'] = $previous;
+            putenv('DATA_PATH=' . $previous);
+        } else {
+            unset($_ENV['DATA_PATH']);
+            putenv('DATA_PATH');
+        }
+    }
 }

--- a/tests/unit/Infrastructure/Persistence/Tenant/TenantRepositoryTest.php
+++ b/tests/unit/Infrastructure/Persistence/Tenant/TenantRepositoryTest.php
@@ -34,10 +34,10 @@ class TenantRepositoryTest extends TestCase
         $tenantRepository->create($tenant);
 
         // Assert
-        $this->assertFileExists(getcwd() . FakeEntityManagerFactory::SQLITE_DATABASE_PATH);
+        $this->assertFileExists(FakeEntityManagerFactory::sqliteDatabaseAbsolutePath());
 
         // Clean up tenant folder
         $fs = new Filesystem();
-        $fs->remove(getcwd() . FakeEntityManagerFactory::DATA_PATH);
+        $fs->remove(FakeEntityManagerFactory::projectRoot() . FakeEntityManagerFactory::DATA_PATH);
     }
 }

--- a/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
+++ b/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
@@ -5,28 +5,35 @@ declare(strict_types=1);
 namespace Phariscope\MultiTenant\Tests\Infrastructure\TenantShortname;
 
 use InvalidArgumentException;
+use org\bovigo\vfs\vfsStream;
+use PDOException;
 use Phariscope\MultiTenant\Infrastructure\TenantShortname\TenantShortnameRegistry;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
 
 class TenantShortnameRegistryTest extends TestCase
 {
-    private string $tmpBase = '';
+    private ?string $savedDataPath = null;
+
+    private bool $savedDataPathInEnv = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        vfsStream::setup('root');
+        $this->savedDataPathInEnv = array_key_exists('DATA_PATH', $_ENV);
+        $this->savedDataPath = $this->savedDataPathInEnv ? $_ENV['DATA_PATH'] : null;
+    }
 
     protected function tearDown(): void
     {
-        if ($this->tmpBase !== '') {
-            (new Filesystem())->remove($this->tmpBase);
-            $this->tmpBase = '';
-        }
+        $this->restoreDataPath();
+        parent::tearDown();
     }
-
 
     public function testRegisterAndResolve(): void
     {
         // Arrange
-        $this->tmpBase = sys_get_temp_dir() . '/mt-reg-' . uniqid('', true);
-        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
+        $registry = $this->registryInMemory();
         $registry->register('tid-abc', 'My-Brand');
 
         // Act
@@ -39,8 +46,7 @@ class TenantShortnameRegistryTest extends TestCase
     public function testRegisterReplacesShortnameForSameTenant(): void
     {
         // Arrange
-        $this->tmpBase = sys_get_temp_dir() . '/mt-reg2-' . uniqid('', true);
-        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
+        $registry = $this->registryInMemory();
         $registry->register('tid-abc', 'first-slug');
         $registry->register('tid-abc', 'second-slug');
 
@@ -56,8 +62,7 @@ class TenantShortnameRegistryTest extends TestCase
     public function testInvalidShortnameThrows(): void
     {
         // Arrange
-        $this->tmpBase = sys_get_temp_dir() . '/mt-reg3-' . uniqid('', true);
-        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
+        $registry = $this->registryInMemory();
         $this->expectException(InvalidArgumentException::class);
 
         // Act
@@ -68,44 +73,36 @@ class TenantShortnameRegistryTest extends TestCase
 
     public function testRegisterAllowsTenantIdAsShortnameWhenEqual(): void
     {
-        $this->tmpBase = sys_get_temp_dir() . '/mt-reg-id-slug-' . uniqid('', true);
-        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
-
+        // Arrange
+        $registry = $this->registryInMemory();
         $registry->register('am_cl_fixed', 'am_cl_fixed');
 
-        $this->assertSame('am_cl_fixed', $registry->resolveTenantId('am_cl_fixed'));
+        // Act
+        $resolved = $registry->resolveTenantId('am_cl_fixed');
+
+        // Assert
+        $this->assertSame('am_cl_fixed', $resolved);
     }
 
     public function testTryCreateFromEnvUsesGetenvWhenNotInSuperglobal(): void
     {
         // Arrange
-        $tmp = sys_get_temp_dir() . '/mt-reg-env-' . uniqid('', true);
-        $hadKey = array_key_exists('DATA_PATH', $_ENV);
-        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+        $dataPath = $this->vfsDataPath('app-env');
         unset($_ENV['DATA_PATH']);
-        putenv('DATA_PATH=' . $tmp);
+        putenv('DATA_PATH=' . $dataPath);
 
         // Act
         $registry = TenantShortnameRegistry::tryCreateFromEnv();
 
         // Assert
         $this->assertNotNull($registry);
-        $this->assertStringEndsWith('tenants/tenants.sqlite', str_replace('\\', '/', $registry->getSqliteFilePath()));
-
-        putenv('DATA_PATH');
-        if ($hadKey && is_string($previous)) {
-            $_ENV['DATA_PATH'] = $previous;
-            putenv('DATA_PATH=' . $previous);
-        } else {
-            putenv('DATA_PATH');
-        }
+        $this->assertEndsWithTenantsSqlite($registry);
+        $this->assertStringStartsWith($dataPath, $registry->getSqliteFilePath());
     }
 
     public function testTryCreateFromEnvReturnsNullWhenDataPathIsEmptyString(): void
     {
         // Arrange
-        $hadKey = array_key_exists('DATA_PATH', $_ENV);
-        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
         $_ENV['DATA_PATH'] = '';
         putenv('DATA_PATH=');
 
@@ -114,27 +111,214 @@ class TenantShortnameRegistryTest extends TestCase
 
         // Assert
         $this->assertNull($registry);
-
-        if ($hadKey && is_string($previous)) {
-            $_ENV['DATA_PATH'] = $previous;
-            putenv('DATA_PATH=' . $previous);
-        } else {
-            unset($_ENV['DATA_PATH']);
-            putenv('DATA_PATH');
-        }
     }
-
 
     public function testResolveReturnsNullForWhitespaceOnlyShortname(): void
     {
         // Arrange
-        $this->tmpBase = sys_get_temp_dir() . '/mt-reg-ws-' . uniqid('', true);
-        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
+        $registry = $this->registryInMemory();
 
         // Act
         $resolved = $registry->resolveTenantId('   ');
 
         // Assert
         $this->assertNull($resolved);
+    }
+
+    public function testRegisterRejectsEmptyTenantId(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('tenant_id must not be empty.');
+
+        // Act
+        $registry->register('', 'valid-slug');
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegisterRejectsEmptyShortname(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('tenant_shortname must not be empty.');
+
+        // Act
+        $registry->register('tid', '   ');
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegisterRejectsShortnameLongerThan63Characters(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $this->expectException(InvalidArgumentException::class);
+
+        // Act
+        $registry->register('tid', str_repeat('a', 64));
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegisterRejectsShortnameWithLeadingHyphen(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $this->expectException(InvalidArgumentException::class);
+
+        // Act
+        $registry->register('tid', '-leading');
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegisterRejectsShortnameWithTrailingHyphen(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $this->expectException(InvalidArgumentException::class);
+
+        // Act
+        $registry->register('tid', 'trailing-');
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegisterRollsBackOnDuplicateShortname(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $registry->register('tid-first', 'shared-slug');
+        $this->expectException(PDOException::class);
+
+        // Act
+        $registry->register('tid-second', 'shared-slug');
+
+        // Assert
+        $this->assertSame('tid-first', $registry->resolveTenantId('shared-slug'));
+    }
+
+    public function testResolveReturnsNullWhenDatabaseFileIsCorrupt(): void
+    {
+        // Arrange
+        vfsStream::setup('root', null, [
+            'tenants' => ['tenants.sqlite' => 'not-a-valid-sqlite-database'],
+        ]);
+        $registry = new TenantShortnameRegistry(vfsStream::url('root/tenants/tenants.sqlite'));
+
+        // Act
+        $resolved = $registry->resolveTenantId('slug-corrupt');
+
+        // Assert
+        $this->assertNull($resolved);
+    }
+
+    public function testRegisterThrowsWhenParentPathCannotBeCreated(): void
+    {
+        // Arrange
+        $root = vfsStream::setup('root');
+        vfsStream::newFile('blocker')->withContent('blocks-directory-creation')->at($root);
+        $registry = new TenantShortnameRegistry(vfsStream::url('root/blocker/nested/tenants.sqlite'));
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('Cannot create directory for tenant shortname registry');
+
+        // Act
+        $registry->register('tid', 'valid-slug');
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testFromApplicationDataPathRestoresEnvWhenDataPathWasUnset(): void
+    {
+        // Arrange
+        $dataPath = $this->vfsDataPath('app-unset');
+        unset($_ENV['DATA_PATH']);
+        putenv('DATA_PATH');
+
+        // Act
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($dataPath);
+
+        // Assert
+        $this->assertEndsWithTenantsSqlite($registry);
+        $this->assertFalse(array_key_exists('DATA_PATH', $_ENV));
+    }
+
+    public function testFromApplicationDataPathBuildsPathUnderVirtualDataRoot(): void
+    {
+        // Arrange
+        $dataPath = $this->vfsDataPath('my-app');
+
+        // Act
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($dataPath);
+
+        // Assert
+        $this->assertSame(
+            vfsStream::url('root/my-app/tenants/tenants.sqlite'),
+            $registry->getSqliteFilePath()
+        );
+    }
+
+    public function testGetPdoCreatesTenantsDirectoryWhenMissing(): void
+    {
+        // Arrange
+        vfsStream::setup('root', null, [
+            'deep' => ['nested' => []],
+        ]);
+        $dataPath = vfsStream::url('root/deep/nested');
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($dataPath);
+        $tenantsDir = vfsStream::url('root/deep/nested/tenants');
+
+        // Act
+        try {
+            $registry->register('tid-mkdir', 'slug-mkdir');
+        } catch (PDOException) {
+            // PDO cannot open SQLite on vfs://; getPdo() still creates the tenants directory.
+        }
+
+        // Assert
+        $this->assertTrue(is_dir($tenantsDir));
+    }
+
+    private function registryInMemory(): TenantShortnameRegistry
+    {
+        return new TenantShortnameRegistry(':memory:');
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function vfsDataPath(string $segment): string
+    {
+        $url = vfsStream::url('root/' . $segment);
+        if ($url === '') {
+            self::fail('vfsStream::url() must not return an empty string.');
+        }
+
+        return $url;
+    }
+
+    private function assertEndsWithTenantsSqlite(TenantShortnameRegistry $registry): void
+    {
+        $this->assertStringEndsWith(
+            'tenants/tenants.sqlite',
+            str_replace('\\', '/', $registry->getSqliteFilePath())
+        );
+    }
+
+    private function restoreDataPath(): void
+    {
+        if ($this->savedDataPathInEnv && is_string($this->savedDataPath)) {
+            $_ENV['DATA_PATH'] = $this->savedDataPath;
+            putenv('DATA_PATH=' . $this->savedDataPath);
+        } elseif ($this->savedDataPathInEnv) {
+            unset($_ENV['DATA_PATH']);
+            putenv('DATA_PATH');
+        } else {
+            unset($_ENV['DATA_PATH']);
+            putenv('DATA_PATH=./var/tmp/data/myApp');
+        }
     }
 }

--- a/tests/unit/Share/IsolatesDataPathEnvTrait.php
+++ b/tests/unit/Share/IsolatesDataPathEnvTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phariscope\MultiTenant\Tests\Share;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+trait IsolatesDataPathEnvTrait
+{
+    /** @var array{hadEnv: bool, env: mixed, getenv: string|false}|null */
+    private ?array $savedDataPathState = null;
+
+    private ?string $isolatedDataPathDir = null;
+
+    protected function setUpIsolatedWritableDataPath(): void
+    {
+        $this->isolatedDataPathDir = sys_get_temp_dir() . '/mt-cmd-' . uniqid('', true);
+        mkdir($this->isolatedDataPathDir, 0775, true);
+        $this->savedDataPathState = $this->captureDataPathEnv();
+        $this->setDataPathEnv($this->isolatedDataPathDir);
+    }
+
+    protected function tearDownIsolatedDataPath(): void
+    {
+        if ($this->savedDataPathState !== null) {
+            $this->restoreDataPathEnv($this->savedDataPathState);
+        }
+
+        if ($this->isolatedDataPathDir !== null && is_dir($this->isolatedDataPathDir)) {
+            (new Filesystem())->remove($this->isolatedDataPathDir);
+            $this->isolatedDataPathDir = null;
+        }
+    }
+
+    protected function setUpDataPathEnvSnapshot(): void
+    {
+        $this->savedDataPathState = $this->captureDataPathEnv();
+    }
+
+    protected function tearDownDataPathEnvSnapshot(): void
+    {
+        if ($this->savedDataPathState !== null) {
+            $this->restoreDataPathEnv($this->savedDataPathState);
+        }
+    }
+
+    protected function clearDataPathEnv(): void
+    {
+        unset($_ENV['DATA_PATH']);
+        putenv('DATA_PATH');
+    }
+
+    /**
+     * @return array{hadEnv: bool, env: mixed, getenv: string|false}
+     */
+    protected function captureDataPathEnv(): array
+    {
+        $getenvValue = getenv('DATA_PATH');
+
+        return [
+            'hadEnv' => array_key_exists('DATA_PATH', $_ENV),
+            'env' => $_ENV['DATA_PATH'] ?? null,
+            'getenv' => is_string($getenvValue) && $getenvValue !== '' ? $getenvValue : false,
+        ];
+    }
+
+    protected function setDataPathEnv(string $path): void
+    {
+        $_ENV['DATA_PATH'] = $path;
+        putenv('DATA_PATH=' . $path);
+    }
+
+    /**
+     * @param array{hadEnv: bool, env: mixed, getenv: string|false} $state
+     */
+    protected function restoreDataPathEnv(array $state): void
+    {
+        if ($state['hadEnv'] && is_string($state['env'])) {
+            $_ENV['DATA_PATH'] = $state['env'];
+        } else {
+            unset($_ENV['DATA_PATH']);
+        }
+
+        if (is_string($state['getenv'])) {
+            putenv('DATA_PATH=' . $state['getenv']);
+        } else {
+            putenv('DATA_PATH');
+        }
+    }
+}


### PR DESCRIPTION
…putenv(DATA_PATH)

dans les tests de commandes et DataFolder, avec répertoire temporaire dédié.

Étendre les tests unitaires :
- commandes tenant (database, schema, update) : cas tenant_id manquant, schéma à jour
- DatabaseTools : échec de connexion, MySQL/MariaDB, createSchema, getUpdateSchemaSql
- TenantShortnameRegistry : validation des slugs, vfsStream, rollback, chemins applicatifs
- TenantRepository, TenantManager, FakeEntityManagerFactory

Corriger les erreurs PHPStan (niveau 9) :
- remplacer Mockery par createMock() PHPUnit pour databaseExists()
- typage nullable de l’état DATA_PATH dans le trait
- vfsStream::newFile()->withContent() et non-empty-string pour assertStringStartsWith

Refactor mineur : DataFolder utilise la constante DATA_PATH_NAME au lieu de la clé en dur.