### PR TITLE
fix(DataFolder): registre shortname global même si DATA_PATH est scop…

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,8 @@
   backupGlobals="false"
   colors="true"
   bootstrap="tests/bootstrap.php"
-  cacheDirectory="var/.phpunit.cache">
+  cacheDirectory="var/.phpunit.cache"
+  displayDetailsOnSkippedTests="true">
   <coverage/>
   <testsuites>
     <testsuite name="all">

--- a/src/DataFolder.php
+++ b/src/DataFolder.php
@@ -41,6 +41,32 @@ class DataFolder implements DataFolderPathInterface
 
     public function getDatabaseTenantsFullPath(): string
     {
-        return sprintf("%s/%s", $this->getDataRootFolder(), "tenants/tenants.sqlite");
+        return sprintf(
+            "%s/%s/%s",
+            $this->getApplicationDataRoot(),
+            self::TENANTS_SUB_FOLDER,
+            'tenants.sqlite'
+        );
+    }
+
+    /**
+     * Application data root (unscoped DATA_PATH), even when $_ENV['DATA_PATH'] was
+     * narrowed to {root}/tenants/{tenantId} by ContextTransformer.
+     */
+    private function getApplicationDataRoot(): string
+    {
+        $dataRoot = $this->getDataRootFolder();
+        $normalized = rtrim(str_replace('\\', '/', $dataRoot), '/');
+
+        $pattern = sprintf('#/%s/([^/]+)$#', preg_quote(self::TENANTS_SUB_FOLDER, '#'));
+        if (preg_match($pattern, $normalized, $matches) === 1) {
+            return substr(
+                $normalized,
+                0,
+                -strlen('/' . self::TENANTS_SUB_FOLDER . '/' . $matches[1])
+            );
+        }
+
+        return $dataRoot;
     }
 }

--- a/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
+++ b/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
@@ -10,8 +10,8 @@ use PDOException;
 use Phariscope\MultiTenant\DataFolder;
 
 /**
- * SQLite registry at {DATA_PATH}/tenants/tenants.sqlite where DATA_PATH is the application root.
- * Path calculation is delegated to DataFolder for consistency.
+ * SQLite registry at {application DATA_PATH}/tenants/tenants.sqlite (global, not per-tenant).
+ * Path calculation is delegated to DataFolder, which normalizes a tenant-scoped DATA_PATH.
  */
 final class TenantShortnameRegistry
 {

--- a/tests/unit/Command/TenantConsoleOptionResolverTest.php
+++ b/tests/unit/Command/TenantConsoleOptionResolverTest.php
@@ -7,6 +7,7 @@ namespace Phariscope\MultiTenant\Tests\Command;
 use InvalidArgumentException;
 use Phariscope\MultiTenant\Command\TenantConsoleOptionResolver;
 use Phariscope\MultiTenant\Infrastructure\TenantShortname\TenantShortnameRegistry;
+use Phariscope\MultiTenant\Tests\Share\IsolatesDataPathEnvTrait;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -16,6 +17,23 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class TenantConsoleOptionResolverTest extends TestCase
 {
+    use IsolatesDataPathEnvTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpDataPathEnvSnapshot();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->isolatedDataPathDir !== null && is_dir($this->isolatedDataPathDir)) {
+            (new Filesystem())->remove($this->isolatedDataPathDir);
+            $this->isolatedDataPathDir = null;
+        }
+
+        $this->tearDownDataPathEnvSnapshot();
+    }
+
     private function definition(): InputDefinition
     {
         return new InputDefinition([
@@ -26,104 +44,97 @@ class TenantConsoleOptionResolverTest extends TestCase
 
     public function testRegistersAndReturnsTenantIdWhenOnlyTenantIdProvided(): void
     {
-        $hadKey = array_key_exists('DATA_PATH', $_ENV);
-        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
-        $tmp = sys_get_temp_dir() . '/mt-tcor-id-' . uniqid('', true);
+        // Arrange
+        $this->isolatedDataPathDir = sys_get_temp_dir() . '/mt-tcor-id-' . uniqid('', true);
+        $this->setDataPathEnv($this->isolatedDataPathDir);
+        $input = new ArrayInput(['--tenant_id' => 't1'], $this->definition());
 
-        try {
-            $_ENV['DATA_PATH'] = $tmp;
-            putenv('DATA_PATH=' . $tmp);
+        // Act
+        $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
 
-            $input = new ArrayInput(['--tenant_id' => 't1'], $this->definition());
-
-            $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
-
-            $this->assertSame('t1', $resolved);
-            $registry = TenantShortnameRegistry::fromApplicationDataPath($tmp);
-            $this->assertSame('t1', $registry->resolveTenantId('t1'));
-        } finally {
-            (new Filesystem())->remove($tmp);
-            if ($hadKey && is_string($previous)) {
-                $_ENV['DATA_PATH'] = $previous;
-                putenv('DATA_PATH=' . $previous);
-            } else {
-                unset($_ENV['DATA_PATH']);
-                putenv('DATA_PATH');
-            }
-        }
+        // Assert
+        $this->assertSame('t1', $resolved);
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->isolatedDataPathDir);
+        $this->assertSame('t1', $registry->resolveTenantId('t1'));
     }
 
     public function testRegistersMappingWhenBothOptionsProvided(): void
     {
-        $hadKey = array_key_exists('DATA_PATH', $_ENV);
-        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
-        $tmp = sys_get_temp_dir() . '/mt-tcor-both-' . uniqid('', true);
+        // Arrange
+        $this->isolatedDataPathDir = sys_get_temp_dir() . '/mt-tcor-both-' . uniqid('', true);
+        $this->setDataPathEnv($this->isolatedDataPathDir);
+        $input = new ArrayInput([
+            '--tenant_id' => 'real-tenant-id',
+            '--tenant_shortname' => 'acme',
+        ], $this->definition());
 
-        try {
-            $_ENV['DATA_PATH'] = $tmp;
-            putenv('DATA_PATH=' . $tmp);
+        // Act
+        $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
 
-            $input = new ArrayInput([
-                '--tenant_id' => 'real-tenant-id',
-                '--tenant_shortname' => 'acme',
-            ], $this->definition());
-
-            $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
-
-            $this->assertSame('real-tenant-id', $resolved);
-            $registry = TenantShortnameRegistry::fromApplicationDataPath($tmp);
-            $this->assertSame('real-tenant-id', $registry->resolveTenantId('acme'));
-        } finally {
-            (new Filesystem())->remove($tmp);
-            if ($hadKey && is_string($previous)) {
-                $_ENV['DATA_PATH'] = $previous;
-                putenv('DATA_PATH=' . $previous);
-            } else {
-                unset($_ENV['DATA_PATH']);
-                putenv('DATA_PATH');
-            }
-        }
+        // Assert
+        $this->assertSame('real-tenant-id', $resolved);
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->isolatedDataPathDir);
+        $this->assertSame('real-tenant-id', $registry->resolveTenantId('acme'));
     }
 
     public function testRejectsNeitherOption(): void
     {
+        // Arrange
         $input = new ArrayInput([], $this->definition());
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Provide --tenant_id.');
 
+        // Act
         TenantConsoleOptionResolver::resolveTenantId($input);
+
+        // Assert - PHPUnit verifies the exception
     }
 
     public function testRejectsShortnameWithoutTenantId(): void
     {
+        // Arrange
         $input = new ArrayInput(['--tenant_shortname' => 'acme'], $this->definition());
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('--tenant_shortname requires --tenant_id.');
 
+        // Act
         TenantConsoleOptionResolver::resolveTenantId($input);
+
+        // Assert - PHPUnit verifies the exception
+    }
+
+    public function testRegistersInGlobalRegistryWhenDataPathIsTenantScoped(): void
+    {
+        // Arrange
+        $this->isolatedDataPathDir = sys_get_temp_dir() . '/mt-tcor-scoped-root-' . uniqid('', true);
+        $scopedPath = $this->isolatedDataPathDir . '/tenants/campus26';
+        $this->setDataPathEnv($scopedPath);
+        $input = new ArrayInput([
+            '--tenant_id' => 'campus26',
+            '--tenant_shortname' => 'c26',
+        ], $this->definition());
+
+        // Act
+        $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
+
+        // Assert
+        $this->assertSame('campus26', $resolved);
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->isolatedDataPathDir);
+        $this->assertSame('campus26', $registry->resolveTenantId('c26'));
+        $this->assertFileDoesNotExist($scopedPath . '/tenants/tenants.sqlite');
     }
 
     public function testThrowsWhenDataPathMissing(): void
     {
-        $hadKey = array_key_exists('DATA_PATH', $_ENV);
-        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
-        unset($_ENV['DATA_PATH']);
-        putenv('DATA_PATH');
-
+        // Arrange
+        $this->clearDataPathEnv();
         $input = new ArrayInput(['--tenant_id' => 't1'], $this->definition());
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('DATA_PATH must be set to register tenant shortname mapping');
 
-        try {
-            TenantConsoleOptionResolver::resolveTenantId($input);
-        } finally {
-            if ($hadKey && is_string($previous)) {
-                $_ENV['DATA_PATH'] = $previous;
-                putenv('DATA_PATH=' . $previous);
-            } else {
-                unset($_ENV['DATA_PATH']);
-                putenv('DATA_PATH');
-            }
-        }
+        // Act
+        TenantConsoleOptionResolver::resolveTenantId($input);
+
+        // Assert - PHPUnit verifies the exception
     }
 }

--- a/tests/unit/ContextTransformerTest.php
+++ b/tests/unit/ContextTransformerTest.php
@@ -306,6 +306,49 @@ class ContextTransformerTest extends TestCase
         );
     }
 
+    public function testTryCreateFromEnvAfterTransformDataPathUsesGlobalShortnameRegistry(): void
+    {
+        $hadKey = array_key_exists('DATA_PATH', $_ENV);
+        $previous = $hadKey ? $_ENV['DATA_PATH'] : null;
+        $appRoot = sys_get_temp_dir() . '/mt-ctx-global-' . uniqid('', true);
+
+        try {
+            $context = [
+                'DATA_PATH' => $appRoot,
+                'argv' => [
+                    'bin/console',
+                    'tenant:database:create',
+                    '--tenant_id',
+                    'campus26',
+                    '--tenant_shortname',
+                    'c26',
+                ],
+            ];
+
+            $transformer = new ContextTransformer($context);
+            $transformer->transformDataPath();
+
+            $this->assertEnvValue('DATA_PATH', $appRoot . '/tenants/campus26');
+
+            $registry = TenantShortnameRegistry::tryCreateFromEnv();
+            $this->assertNotNull($registry);
+            $registry->register('campus26', 'c26');
+
+            $globalRegistry = TenantShortnameRegistry::fromApplicationDataPath($appRoot);
+            $this->assertSame('campus26', $globalRegistry->resolveTenantId('c26'));
+            $this->assertFileDoesNotExist($appRoot . '/tenants/campus26/tenants/tenants.sqlite');
+        } finally {
+            (new Filesystem())->remove($appRoot);
+            if ($hadKey && is_string($previous)) {
+                $_ENV['DATA_PATH'] = $previous;
+                putenv('DATA_PATH=' . $previous);
+            } else {
+                unset($_ENV['DATA_PATH']);
+                putenv('DATA_PATH');
+            }
+        }
+    }
+
     public function testTransformDataPathWithTenantShortnameInArgv(): void
     {
         // Arrange

--- a/tests/unit/DataFolderTest.php
+++ b/tests/unit/DataFolderTest.php
@@ -176,4 +176,18 @@ class DataFolderTest extends TestCase
         // Assert
         $this->assertEquals($expectedPath, $actualPath);
     }
+
+    public function testGetDatabaseTenantsFullPathWhenDataPathIsTenantScoped(): void
+    {
+        // Arrange — simulates ContextTransformer after --tenant_id
+        $_ENV['DATA_PATH'] = '/tmp/app/tenants/campus26';
+        $dataFolder = new DataFolder();
+        $expectedPath = '/tmp/app/tenants/tenants.sqlite';
+
+        // Act
+        $actualPath = $dataFolder->getDatabaseTenantsFullPath();
+
+        // Assert
+        $this->assertEquals($expectedPath, $actualPath);
+    }
 }

--- a/tests/unit/Doctrine/DatabaseToolsTest.php
+++ b/tests/unit/Doctrine/DatabaseToolsTest.php
@@ -18,6 +18,14 @@ use function SafePHP\strval;
 
 class DatabaseToolsTest extends TestCase
 {
+    private const MARIADB_SKIP_MESSAGE = <<<'MSG'
+MariaDB is not reachable at host "mariadb:3306" (required for MySQL/MariaDB coverage).
+Start the service, then re-run the tests:
+
+  docker compose up -d mariadb
+  bin/phpunit tests/unit/Doctrine/DatabaseToolsTest.php
+MSG;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -235,10 +243,8 @@ class DatabaseToolsTest extends TestCase
 
     private function skipIfMariaDbUnavailable(): void
     {
-        try {
-            (new FakeEntityManagerFactory())->cleanMariadbDatabase();
-        } catch (\Throwable) {
-            $this->markTestSkipped('MariaDB is not available for non-SQLite DatabaseTools coverage.');
+        if (!(new FakeEntityManagerFactory())->isMariaDbReachable()) {
+            $this->markTestSkipped(self::MARIADB_SKIP_MESSAGE);
         }
     }
 }

--- a/tests/unit/Doctrine/Tools/FakeEntityManagerFactory.php
+++ b/tests/unit/Doctrine/Tools/FakeEntityManagerFactory.php
@@ -92,6 +92,31 @@ class FakeEntityManagerFactory
         return $this->createEntityManager($connection);
     }
 
+    /**
+     * Fast TCP probe (1s) — avoids long PDO timeouts when MariaDB is down.
+     */
+    public function isMariaDbReachable(): bool
+    {
+        static $reachable = null;
+        if ($reachable !== null) {
+            return $reachable;
+        }
+
+        $errno = 0;
+        $errstr = '';
+        $socket = @fsockopen('mariadb', 3306, $errno, $errstr, 1);
+        if (is_resource($socket)) {
+            fclose($socket);
+            $reachable = true;
+
+            return true;
+        }
+
+        $reachable = false;
+
+        return false;
+    }
+
     public function cleanMariadbDatabase(): void
     {
         $connection = DriverManager::getConnection(

--- a/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
+++ b/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
@@ -261,6 +261,24 @@ class TenantShortnameRegistryTest extends TestCase
         );
     }
 
+    public function testTryCreateFromEnvUsesApplicationRootWhenDataPathIsTenantScoped(): void
+    {
+        // Arrange — simulates ContextTransformer narrowing DATA_PATH
+        $appRoot = $this->vfsDataPath('app-scoped');
+        $_ENV['DATA_PATH'] = $appRoot . '/tenants/campus26';
+        putenv('DATA_PATH=' . $_ENV['DATA_PATH']);
+
+        // Act
+        $registry = TenantShortnameRegistry::tryCreateFromEnv();
+
+        // Assert
+        $this->assertNotNull($registry);
+        $this->assertSame(
+            vfsStream::url('root/app-scoped/tenants/tenants.sqlite'),
+            $registry->getSqliteFilePath()
+        );
+    }
+
     public function testGetPdoCreatesTenantsDirectoryWhenMissing(): void
     {
         // Arrange


### PR DESCRIPTION
…é tenant

Quand ContextTransformer réduit DATA_PATH vers {racine}/tenants/{tenant_id} (avant bootstrap Symfony, ex. bin/console avec --tenant_id), le registre SQLite des shortnames était créé sous
{racine}/tenants/{tenant_id}/tenants/tenants.sqlite au lieu de {racine}/tenants/tenants.sqlite.

Ajoute getApplicationDataRoot() dans DataFolder pour remonter à la racine applicative lorsque DATA_PATH se termine par /tenants/{id}, et l’utilise uniquement dans getDatabaseTenantsFullPath(). Les chemins métier tenant (getTenantDataFolder, etc.) restent basés sur DATA_PATH tel quel.

Impact : TenantShortnameRegistry::tryCreateFromEnv(), TenantConsoleOptionResolver, CreateTenantService et TenantManager écrivent/lisent tous le même fichier global sans changement d’API.

Tests :
- DataFolder : DATA_PATH scopé → chemin tenants/tenants.sqlite à la racine
- TenantShortnameRegistry : tryCreateFromEnv avec DATA_PATH scopé
- TenantConsoleOptionResolver : enregistrement sans base parasite sous le tenant
- ContextTransformer : transformDataPath puis enregistrement shortname