### PR TITLE
feat(shortname): allouer automatiquement un slug unique en cas de col…

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ Supported inputs mirror `tenant_id`: query/body parameters, session keys, cookie
 
 When creating or provisioning a tenant, the registry is updated in `tenants.sqlite`:
 
-- **`CreateTenantService`**: always writes a mapping (`DATA_PATH` required). If `tenantShortname` is omitted, the shortname stored equals `tenant_id`.
+- **`CreateTenantService`**: always writes a mapping (`DATA_PATH` required). If `tenantShortname` is omitted, the shortname stored equals `tenant_id`. The response includes the **final** shortname assigned.
 - **Bundle console commands** (`tenant:database:create`, `tenant:schema:create`, `tenant:schema:update`): `--tenant_id` is **required**. Optional `--tenant_shortname` registers a custom slug; if omitted, the shortname stored equals `tenant_id`. `--tenant_shortname` alone is rejected.
 - **`tenant:shortname:show`**: read-only lookup from `tenant_id` to the registered shortname (requires `DATA_PATH` and an existing row in `tenants.sqlite`).
+
+**Shortname collisions:** if the requested `tenant_shortname` is already used by another tenant, a numeric suffix is appended automatically (`my-school` → `my-school-2`, then `my-school-3`, etc.) until a free slug is found. The same rules apply in `CreateTenantService` and in console provisioning when `--tenant_shortname` is provided.
 
 Console examples:
 

--- a/src/Application/Service/Tenant/CreateTenant/CreateTenantResponse.php
+++ b/src/Application/Service/Tenant/CreateTenant/CreateTenantResponse.php
@@ -8,6 +8,7 @@ class CreateTenantResponse implements Response
 {
     public function __construct(
         public readonly string $tenantId,
+        public readonly string $tenantShortname,
     ) {
     }
 }

--- a/src/Application/Service/Tenant/CreateTenant/CreateTenantResponse.php
+++ b/src/Application/Service/Tenant/CreateTenant/CreateTenantResponse.php
@@ -8,7 +8,7 @@ class CreateTenantResponse implements Response
 {
     public function __construct(
         public readonly string $tenantId,
-        public readonly string $tenantShortname,
+        public readonly string $tenantShortname = '',
     ) {
     }
 }

--- a/src/Application/Service/Tenant/CreateTenant/CreateTenantService.php
+++ b/src/Application/Service/Tenant/CreateTenant/CreateTenantService.php
@@ -33,9 +33,12 @@ class CreateTenantService
         $shortname = $request->tenantShortname !== null && $request->tenantShortname !== ''
             ? $request->tenantShortname
             : $tenant->getTenantId();
-        $registry->register($tenant->getTenantId(), $shortname);
+        $registeredShortname = $registry->registerUniqueShortname($tenant->getTenantId(), $shortname);
 
-        $this->response = new CreateTenantResponse(tenantId: $tenant->getTenantId());
+        $this->response = new CreateTenantResponse(
+            tenantId: $tenant->getTenantId(),
+            tenantShortname: $registeredShortname,
+        );
     }
 
     public function getResponse(): CreateTenantResponse

--- a/src/Command/TenantConsoleOptionResolver.php
+++ b/src/Command/TenantConsoleOptionResolver.php
@@ -34,7 +34,7 @@ final class TenantConsoleOptionResolver
         }
 
         $shortnameToRegister = $shortnameString !== '' ? $shortnameString : $tenantIdString;
-        $registry->register($tenantIdString, $shortnameToRegister);
+        $registry->registerUniqueShortname($tenantIdString, $shortnameToRegister);
 
         return $tenantIdString;
     }

--- a/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
+++ b/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PDO;
 use PDOException;
 use Phariscope\MultiTenant\DataFolder;
+use RuntimeException;
 
 /**
  * SQLite registry at {application DATA_PATH}/tenants/tenants.sqlite (global, not per-tenant).
@@ -15,6 +16,8 @@ use Phariscope\MultiTenant\DataFolder;
  */
 final class TenantShortnameRegistry
 {
+    private const MAX_UNIQUE_SHORTNAME_ATTEMPTS = 100;
+
     private ?PDO $pdo = null;
 
     public function __construct(
@@ -115,7 +118,7 @@ final class TenantShortnameRegistry
             throw new InvalidArgumentException('tenant_shortname must not be empty.');
         }
 
-        if (strtolower($tenantId) !== $key && !self::isValidShortname($key)) {
+        if (!self::isAllowedShortname($tenantId, $key)) {
             throw new InvalidArgumentException(
                 'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-63 chars).'
             );
@@ -135,6 +138,63 @@ final class TenantShortnameRegistry
             $pdo->rollBack();
             throw $e;
         }
+    }
+
+    /**
+     * Registers a shortname for the tenant, allocating a unique variant when the desired slug is taken.
+     * Tries the base slug first, then {@code base-2}, {@code base-3}, etc.
+     *
+     * @return non-empty-string the shortname actually stored (normalized)
+     */
+    public function registerUniqueShortname(string $tenantId, string $desiredShortname): string
+    {
+        if ($tenantId === '') {
+            throw new InvalidArgumentException('tenant_id must not be empty.');
+        }
+
+        $base = self::normalizeShortname($desiredShortname);
+        if ($base === '') {
+            throw new InvalidArgumentException('tenant_shortname must not be empty.');
+        }
+
+        if (!self::isAllowedShortname($tenantId, $base)) {
+            throw new InvalidArgumentException(
+                'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-63 chars).'
+            );
+        }
+
+        for ($attempt = 0; $attempt < self::MAX_UNIQUE_SHORTNAME_ATTEMPTS; ++$attempt) {
+            $candidate = $attempt === 0
+                ? $base
+                : self::buildSuffixedShortname($base, $attempt + 1);
+
+            if (!self::isAllowedShortname($tenantId, $candidate)) {
+                continue;
+            }
+
+            $owner = $this->resolveTenantId($candidate);
+            if ($owner !== null && $owner !== $tenantId) {
+                continue;
+            }
+
+            try {
+                $this->register($tenantId, $candidate);
+
+                return $candidate;
+            } catch (PDOException $e) {
+                if (!self::isUniqueConstraintViolation($e)) {
+                    throw $e;
+                }
+            }
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Could not allocate a unique tenant_shortname after %d attempts (base: %s).',
+                self::MAX_UNIQUE_SHORTNAME_ATTEMPTS,
+                $base
+            )
+        );
     }
 
     private function getPdo(): PDO
@@ -179,5 +239,48 @@ final class TenantShortnameRegistry
         }
 
         return preg_match('/^[a-z0-9-]+$/', $normalized) === 1;
+    }
+
+    private static function isAllowedShortname(string $tenantId, string $normalized): bool
+    {
+        if (strtolower($tenantId) === $normalized) {
+            return true;
+        }
+
+        if (self::isValidShortname($normalized)) {
+            return true;
+        }
+
+        $tenantLower = strtolower($tenantId);
+        $pattern = '/^' . preg_quote($tenantLower, '/') . '-\d+$/';
+
+        return preg_match($pattern, $normalized) === 1;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function buildSuffixedShortname(string $base, int $suffixNumber): string
+    {
+        $suffix = '-' . (string) $suffixNumber;
+        $maxBaseLength = 63 - strlen($suffix);
+        $truncated = substr($base, 0, max(1, $maxBaseLength));
+        $truncated = rtrim($truncated, '-');
+        if ($truncated === '') {
+            throw new InvalidArgumentException('tenant_shortname base is too long to append a numeric suffix.');
+        }
+
+        return $truncated . $suffix;
+    }
+
+    private static function isUniqueConstraintViolation(PDOException $e): bool
+    {
+        if ($e->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $e->getMessage();
+
+        return stripos($message, 'UNIQUE constraint failed') !== false;
     }
 }

--- a/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
+++ b/src/Infrastructure/TenantShortname/TenantShortnameRegistry.php
@@ -18,6 +18,9 @@ final class TenantShortnameRegistry
 {
     private const MAX_UNIQUE_SHORTNAME_ATTEMPTS = 100;
 
+    /** RFC 1035 maximum length of a single DNS label. */
+    private const MAX_SHORTNAME_LENGTH = 63;
+
     private ?PDO $pdo = null;
 
     public function __construct(
@@ -120,7 +123,10 @@ final class TenantShortnameRegistry
 
         if (!self::isAllowedShortname($tenantId, $key)) {
             throw new InvalidArgumentException(
-                'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-63 chars).'
+                sprintf(
+                    'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-%d chars).',
+                    self::MAX_SHORTNAME_LENGTH
+                )
             );
         }
 
@@ -159,7 +165,10 @@ final class TenantShortnameRegistry
 
         if (!self::isAllowedShortname($tenantId, $base)) {
             throw new InvalidArgumentException(
-                'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-63 chars).'
+                sprintf(
+                    'tenant_shortname must be a DNS-like label (lowercase letters, digits, hyphen; 1-%d chars).',
+                    self::MAX_SHORTNAME_LENGTH
+                )
             );
         }
 
@@ -230,7 +239,7 @@ final class TenantShortnameRegistry
 
     private static function isValidShortname(string $normalized): bool
     {
-        if (strlen($normalized) < 1 || strlen($normalized) > 63) {
+        if (strlen($normalized) < 1 || strlen($normalized) > self::MAX_SHORTNAME_LENGTH) {
             return false;
         }
 
@@ -263,7 +272,7 @@ final class TenantShortnameRegistry
     private static function buildSuffixedShortname(string $base, int $suffixNumber): string
     {
         $suffix = '-' . (string) $suffixNumber;
-        $maxBaseLength = 63 - strlen($suffix);
+        $maxBaseLength = self::MAX_SHORTNAME_LENGTH - strlen($suffix);
         $truncated = substr($base, 0, max(1, $maxBaseLength));
         $truncated = rtrim($truncated, '-');
         if ($truncated === '') {

--- a/tests/unit/Application/Service/Tenant/CreateTenant/CreateTenantServiceTest.php
+++ b/tests/unit/Application/Service/Tenant/CreateTenant/CreateTenantServiceTest.php
@@ -34,6 +34,7 @@ class CreateTenantServiceTest extends TestCase
         $response = $sut->getResponse();
 
         $this->assertEquals('am_cl_1234567890', $response->tenantId);
+        $this->assertSame('am_cl_1234567890', $response->tenantShortname);
         $this->assertSame('am_cl_1234567890', $registry->resolveTenantId('am_cl_1234567890'));
     }
 
@@ -49,8 +50,29 @@ class CreateTenantServiceTest extends TestCase
         $sut = new CreateTenantService(new TenantRepositoryInMemory(), $registry);
 
         $sut->execute($request);
+        $response = $sut->getResponse();
 
+        $this->assertSame('campus-26', $response->tenantShortname);
         $this->assertSame('am_cl_1234567890', $registry->resolveTenantId('campus-26'));
+    }
+
+    public function testExecuteAllocatesSuffixWhenShortnameTaken(): void
+    {
+        $this->tmpBase = sys_get_temp_dir() . '/mt-cts-' . uniqid('', true);
+        $registry = TenantShortnameRegistry::fromApplicationDataPath($this->tmpBase);
+        $registry->register('existing-tenant', 'campus-26');
+
+        $request = new CreateTenantRequest(
+            tenantId: 'am_cl_new',
+            tenantShortname: 'campus-26',
+        );
+        $sut = new CreateTenantService(new TenantRepositoryInMemory(), $registry);
+
+        $sut->execute($request);
+        $response = $sut->getResponse();
+
+        $this->assertSame('campus-26-2', $response->tenantShortname);
+        $this->assertSame('am_cl_new', $registry->resolveTenantId('campus-26-2'));
     }
 
     public function testExecuteCallsTenantRepositoryCreate(): void

--- a/tests/unit/Command/TenantConsoleOptionResolverTest.php
+++ b/tests/unit/Command/TenantConsoleOptionResolverTest.php
@@ -77,6 +77,26 @@ class TenantConsoleOptionResolverTest extends TestCase
         $this->assertSame('real-tenant-id', $registry->resolveTenantId('acme'));
     }
 
+    public function testRegistersUniqueSuffixWhenShortnameTaken(): void
+    {
+        // Arrange
+        $this->isolatedDataPathDir = sys_get_temp_dir() . '/mt-tcor-collision-' . uniqid('', true);
+        $this->setDataPathEnv($this->isolatedDataPathDir);
+        $registry = $this->registryForIsolatedDataPath();
+        $registry->register('other-tenant', 'acme');
+        $input = new ArrayInput([
+            '--tenant_id' => 'new-tenant-id',
+            '--tenant_shortname' => 'acme',
+        ], $this->definition());
+
+        // Act
+        $resolved = TenantConsoleOptionResolver::resolveTenantId($input);
+
+        // Assert
+        $this->assertSame('new-tenant-id', $resolved);
+        $this->assertSame('new-tenant-id', $registry->resolveTenantId('acme-2'));
+    }
+
     public function testRejectsNeitherOption(): void
     {
         // Arrange

--- a/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
+++ b/tests/unit/Infrastructure/TenantShortname/TenantShortnameRegistryTest.php
@@ -253,6 +253,50 @@ class TenantShortnameRegistryTest extends TestCase
         $this->assertSame('tid-first', $registry->resolveTenantId('shared-slug'));
     }
 
+    public function testRegisterUniqueAllocatesSuffixOnCollision(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $registry->register('tid-first', 'acme');
+
+        // Act
+        $allocated = $registry->registerUniqueShortname('tid-second', 'acme');
+
+        // Assert
+        $this->assertSame('acme-2', $allocated);
+        $this->assertSame('tid-second', $registry->resolveTenantId('acme-2'));
+        $this->assertSame('tid-first', $registry->resolveTenantId('acme'));
+    }
+
+    public function testRegisterUniqueAllocatesNextSuffixWhenMultipleTaken(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $registry->register('tid-first', 'acme');
+        $registry->register('tid-second', 'acme-2');
+
+        // Act
+        $allocated = $registry->registerUniqueShortname('tid-third', 'acme');
+
+        // Assert
+        $this->assertSame('acme-3', $allocated);
+        $this->assertSame('tid-third', $registry->resolveTenantId('acme-3'));
+    }
+
+    public function testRegisterUniqueIsIdempotentForSameTenant(): void
+    {
+        // Arrange
+        $registry = $this->registryInMemory();
+        $registry->register('tid-abc', 'my-brand');
+
+        // Act
+        $allocated = $registry->registerUniqueShortname('tid-abc', 'My-Brand');
+
+        // Assert
+        $this->assertSame('my-brand', $allocated);
+        $this->assertSame('tid-abc', $registry->resolveTenantId('my-brand'));
+    }
+
     public function testResolveReturnsNullWhenDatabaseFileIsCorrupt(): void
     {
         // Arrange


### PR DESCRIPTION
…lision

Lorsqu’un tenant_shortname est déjà pris par un autre tenant, on enregistre une variante suffixée (ex. campus-26 → campus-26-2) au lieu d’échouer sur la contrainte UNIQUE SQLite.

- Ajout de TenantShortnameRegistry::registerUniqueShortname()
- Utilisation dans CreateTenantService et TenantConsoleOptionResolver
- CreateTenantResponse expose le shortname final attribué
- Tests unitaires et documentation README